### PR TITLE
Add codespell test for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 - 👋 Hi, I’m @DavidMarrs1588 I am an Electrical Engineering Senior at Virginia Commonwealth University in Richmond, Virginia, US. Graduation Fall 2022. 
      I double major in physics and minor in math. I've worked primarily with optical systems. 
 - 👀 I’m interested in numerical methods for electronic and photonic device design. 
-- 🌱 I’m currently learning python to do basic numerical computations for homeworks, image processing and Networking for some projects. 
-- 💞️ I’m looking to collaborate on academic projects related to electrical engineering and phyiscs.
+- 🌱 I’m currently learning python to do basic numerical computations for homework, image processing and networking for some projects.
+- 💞️ I’m looking to collaborate on academic projects related to electrical engineering and physics.
 - 📫 How to reach me 
 marrsjd@vcu.edu
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest
+codespell

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,13 @@
+import subprocess
+from pathlib import Path
+
+
+def test_readme_has_no_spelling_errors():
+    readme = Path(__file__).resolve().parents[1] / 'README.md'
+    result = subprocess.run(
+        ['codespell', str(readme)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout


### PR DESCRIPTION
## Summary
- add pytest test that runs codespell against README
- add test requirements with pytest and codespell
- fix spelling issues in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68976be0800883288b302aa1b2ddfe27